### PR TITLE
Add caching for muddler

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -11,5 +11,22 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - run: ${{ github.action_path }}/muddle.sh ${{ inputs.muddlerVersion }}
+    - name: Set muddler version
+      run: ${{ github.action_path }}/set-muddler-version.sh ${{ inputs.muddlerVersion }}
+      shell: bash
+    
+    - name: Restore muddler from cache
+      uses: actions/cache@v3
+      id: cache-muddler
+      with:
+        path: /tmp/muddler
+        key: muddler-${{ env.MUDDLER_VERSION }}
+    
+    - name: download muddler
+      if: steps.cache-muddler.outputs.cache-hit != 'true'
+      run: ${{ github.action_path }}/download-muddler.sh ${{ env.MUDDLER_VERSION }}
+      shell: bash
+
+    - name: Run muddler
+      run: ${{ github.action_path }}/muddle.sh
       shell: bash

--- a/download-muddler.sh
+++ b/download-muddler.sh
@@ -1,0 +1,9 @@
+VERSION=$1
+cd /tmp
+echo "Downloading muddler version: $VERSION"
+curl -L "https://github.com/demonnic/muddler/releases/download/$VERSION/muddle-shadow-$VERSION.tar" --output muddler.tar
+mkdir muddler-tmp
+tar xf muddler.tar -C muddler-tmp
+mv muddler-tmp/muddle-shadow-$VERSION muddler
+rm -rf muddler-tmp muddler.tar
+echo "Muddler downloaded successfully"

--- a/muddle.sh
+++ b/muddle.sh
@@ -1,17 +1,6 @@
 cd $GITHUB_WORKSPACE
-if [[ "$1" == "LATEST" ]]; then
-  VERSION=`curl --silent "https://api.github.com/repos/demonnic/muddler/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")'`
-else
-  VERSION="$1"
-fi
-echo "Using Muddler version: $VERSION"
-curl -L https://github.com/demonnic/muddler/releases/download/$VERSION/muddle-shadow-$VERSION.tar --output muddler.tar &&\
-mkdir muddler-tmp &&\
-tar xf muddler.tar -C muddler-tmp &&\
-mv muddler-tmp/muddle-shadow-$VERSION muddler &&\
-rm -rf muddler-tmp muddler.tar &&\
-muddler/bin/muddle &&\
-rm -rf muddler
+
+/tmp/muddler/bin/muddle
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then
   echo "Muddler build failed with exit status: $EXIT_CODE"

--- a/set-muddler-version.sh
+++ b/set-muddler-version.sh
@@ -1,0 +1,9 @@
+if [[ "$1" == "LATEST" ]]; then
+  VERSION=`curl --silent "https://api.github.com/repos/demonnic/muddler/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")'`
+else
+  VERSION="$1"
+fi
+
+echo "Using muddler version: $VERSION"
+
+echo "MUDDLER_VERSION=$VERSION" >> $GITHUB_ENV


### PR DESCRIPTION
Now that I'm more familiar with how to cache dependencies, let's cache muddler so it doesn't have to download for every single run.