### PR TITLE
Allow setting working directory for action run

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A github action to build your Mudlet project with [muddler](https://github.com/d
 Name | Description | Default
 --- | --- | ---
 muddlerVersion | the version of Muddler to use | LATEST
+workingDir | what directory to run muddler in | ${{ github.workspace }}
 
 ## Usage Example
 

--- a/action.yaml
+++ b/action.yaml
@@ -8,6 +8,10 @@ inputs:
     description: 'Version of muddler to use'
     required: false
     default: 'LATEST'
+  workingDir:
+    description: 'What directory to run muddler in.'
+    required: false
+    default: ${{ github.workspace }}
 runs:
   using: "composite"
   steps:
@@ -28,5 +32,5 @@ runs:
       shell: bash
 
     - name: Run muddler
-      run: ${{ github.action_path }}/muddle.sh
+      run: cd ${{inputs.workingDir}} && ${{ github.action_path }}/muddle.sh
       shell: bash

--- a/muddle.sh
+++ b/muddle.sh
@@ -1,5 +1,3 @@
-cd $GITHUB_WORKSPACE
-
 /tmp/muddler/bin/muddle
 EXIT_CODE=$?
 if [ $EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
This adjustment allows you to set a working directory for the action, so you can muddle packages which aren't the top level of the repository. This also allows for running the action against multiple projects in a single repository.